### PR TITLE
Parse rich text shared strings correctly

### DIFF
--- a/lib/creek/shared_strings.rb
+++ b/lib/creek/shared_strings.rb
@@ -14,14 +14,31 @@ module Creek
 
     def parse_shared_shared_strings
       path = "xl/sharedStrings.xml"
-      @dictionary = Hash.new
       if @book.files.file.exist?(path)
         doc = @book.files.file.open path
         xml = Nokogiri::XML::Document.parse doc
-        xml.css('t').each_with_index.map  do |str, i|
-          @dictionary[i] = str.content
-        end
+        parse_shared_string_from_document(xml)
       end
     end
+
+    def parse_shared_string_from_document(xml)
+      @dictionary = self.class.parse_shared_string_from_document(xml)
+    end
+
+    def self.parse_shared_string_from_document(xml)
+      dictionary = Hash.new
+
+      xml.css('si').each_with_index do |si, idx|
+        text_nodes = si.css('t')
+        if text_nodes.count == 1 # plain text node
+          dictionary[idx] = text_nodes.first.content
+        else # rich text nodes with text fragments
+          dictionary[idx] = text_nodes.map(&:content).join('')
+        end
+      end
+
+      dictionary
+    end
+
   end
 end

--- a/spec/fixtures/sst.xml
+++ b/spec/fixtures/sst.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="6" uniqueCount="5">
+    <si>
+        <t>Cell A1</t>
+    </si>
+    <si>
+        <t>Cell B1</t>
+    </si>
+    <si>
+        <t>My Cell</t>
+    </si>
+    <si>
+        <r>
+            <rPr>
+                <sz val="11"/>
+                <color rgb="FFFF0000"/>
+                <rFont val="Calibri"/>
+                <family val="2"/>
+                <scheme val="minor"/>
+            </rPr>
+            <t>Cell</t>
+        </r>
+        <r>
+            <rPr>
+                <sz val="11"/>
+                <color theme="1"/>
+                <rFont val="Calibri"/>
+                <family val="2"/>
+                <scheme val="minor"/>
+            </rPr>
+            <t xml:space="preserve"> </t>
+        </r>
+        <r>
+            <rPr>
+                <b/>
+                <sz val="11"/>
+                <color theme="1"/>
+                <rFont val="Calibri"/>
+                <family val="2"/>
+                <scheme val="minor"/>
+            </rPr>
+            <t>A2</t>
+        </r>
+    </si>
+    <si>
+        <r>
+            <rPr>
+                <sz val="11"/>
+                <color rgb="FF00B0F0"/>
+                <rFont val="Calibri"/>
+                <family val="2"/>
+                <scheme val="minor"/>
+            </rPr>
+            <t>Cell</t>
+        </r>
+        <r>
+            <rPr>
+                <sz val="11"/>
+                <color theme="1"/>
+                <rFont val="Calibri"/>
+                <family val="2"/>
+                <scheme val="minor"/>
+            </rPr>
+            <t xml:space="preserve"> </t>
+        </r>
+        <r>
+            <rPr>
+                <i/>
+                <sz val="11"/>
+                <color theme="1"/>
+                <rFont val="Calibri"/>
+                <family val="2"/>
+                <scheme val="minor"/>
+            </rPr>
+            <t>B2</t>
+        </r>
+    </si>
+</sst>

--- a/spec/shared_string_spec.rb
+++ b/spec/shared_string_spec.rb
@@ -1,0 +1,18 @@
+require 'creek'
+
+describe 'shared strings' do
+
+  it 'parses rich text strings correctly' do
+    shared_strings_xml_file = File.open('spec/fixtures/sst.xml')
+    doc = Nokogiri::XML(shared_strings_xml_file)
+    dictionary = Creek::SharedStrings.parse_shared_string_from_document(doc)
+
+    dictionary.keys.size.should == 5
+    dictionary[0].should == 'Cell A1'
+    dictionary[1].should == 'Cell B1'
+    dictionary[2].should == 'My Cell'
+    dictionary[3].should == 'Cell A2'
+    dictionary[4].should == 'Cell B2'
+  end
+
+end


### PR DESCRIPTION
Hi,

I experienced some problems with complex Excel sheets with rich text strings.
In the current version, you only support plain text shared strings. When parsing rich text strings, the shared string dictionary is corrupted.

According to the official documentation regarding shared strings (http://msdn.microsoft.com/en-us/library/office/gg278314%28v=office.15%29.aspx), I implemented changes that also supports rich text strings (although ignoring their formatting, as this is useless in the context of creek).

Although my changes work for Excel documents I tested against (I also included a spec which checks against the shared string example in the documentation), I'd appreciate a review of my changes.

Thank you very much in advance!
