### PR TITLE
restrict value can be only retrieved from v node

### DIFF
--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -83,9 +83,9 @@ module Creek
                 cell_style_idx = node.attributes['s']
                 cell           = node.attributes['r']
 
-              elsif node.value?
+              elsif (node.name.eql? 'v') and (node.node_type.eql? opener)
                 if !cell.nil?
-                  cells[cell] = convert(node.value, cell_type, cell_style_idx)
+                  cells[cell] = convert(node.inner_xml, cell_type, cell_style_idx)
                 end
               end
             end


### PR DESCRIPTION
This is linked to pythonicrubyist/creek#16.

For some reason, excel row can have some random nodes which responds "value?"  true as well. However, those value are not people really want. 