### PR TITLE
Gets the name of the sheet from the workbook.xml.rels file

### DIFF
--- a/lib/creek/book.rb
+++ b/lib/creek/book.rb
@@ -22,8 +22,11 @@ module Creek
     def sheets
       doc = @files.file.open "xl/workbook.xml"
       xml = Nokogiri::XML::Document.parse doc
-      @sheets = xml.css('sheet').each_with_index.map  do |sheet, i|
-        Sheet.new(self, sheet.attr("name"), sheet.attr("sheetid"),  sheet.attr("state"), sheet.attr("visible"), sheet.attr("r:id"), i+1)
+      rels_doc = @files.file.open "xl/_rels/workbook.xml.rels"
+      rels = Nokogiri::XML::Document.parse(rels_doc).css("Relationship")
+      @sheets = xml.css('sheet').map do |sheet|
+        sheetfile = rels.find { |el| sheet.attr("r:id") == el.attr("Id") }.attr("Target")
+        Sheet.new(self, sheet.attr("name"), sheet.attr("sheetid"),  sheet.attr("state"), sheet.attr("visible"), sheet.attr("r:id"), sheetfile)
       end
     end
 

--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -13,14 +13,14 @@ module Creek
                 :index
 
 
-    def initialize book, name, sheetid, state, visible, rid, index
+    def initialize book, name, sheetid, state, visible, rid, sheetfile
       @book = book
       @name = name
       @sheetid = sheetid
       @visible = visible
       @rid = rid
       @state = state
-      @index = index
+      @sheetfile = sheetfile
 
       # An XLS file has only 256 columns, however, an XLSX or XLSM file can contain up to 16384 columns.
       # This function creates a hash with all valid XLSX column names and associated indices.
@@ -57,7 +57,7 @@ module Creek
     # Returns a hash per row that includes the cell ids and values.
     # Empty cells will be also included in the hash with a nil value.
     def rows_generator include_meta_data=false
-      path = "xl/worksheets/sheet#{@index}.xml"
+      path = "xl/#{@sheetfile}"
       if @book.files.file.exist?(path)
         # SAX parsing, Each element in the stream comes through as two events:
         # one to open the element and one to close it.


### PR DESCRIPTION
Creek currently just saves the order of the declaration of the \<sheet> tags as an index and uses that to get the sheet xml file. 

While it is true that the order will usually be the same as the number on the ids and the number of the sheet, it is not **strictly** true. If the sheets are rearranged after creation and also depending on the tool used to generate the .xlsx file, they can come out in strange orders. 

This should make sure it will find the right sheet by going to workbook.xml.rels and matching the r:id in the worksheet relationships to find the corresponding sheet path.

Fixes #19 