### PR TITLE
fixed an issue with col_name causing it to fail generating names for …

### DIFF
--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -49,7 +49,7 @@ module Creek
     # Returns valid Excel column name for a given column index.
     # For example, returns "A" for 0, "B" for 1 and "AQ" for 42.
     def col_name i
-      quot = i/26
+      quot = (i/26).floor
       (quot>0 ? col_name(quot-1) : "") + (i%26+65).chr
     end
 


### PR DESCRIPTION
…single letter columns

I was getting this error from initializing a sheet when col_name(1) was called.  I'm using ruby 2.2, not sure if this has something to do with it but I'm not sure how this method worked originally since (1/26)>0.

```
NoMethodError: undefined method `chr' for (2341/26):Rational
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/sheet.rb:53:in `col_name'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/sheet.rb:53:in `col_name'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/sheet.rb:29:in `block in initialize'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/core_ext/range/each.rb:7:in `each'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/core_ext/range/each.rb:7:in `each_with_time_with_zone'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/sheet.rb:28:in `initialize'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/book.rb:29:in `new'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/book.rb:29:in `block in sheets'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node_set.rb:187:in `block in each'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node_set.rb:186:in `upto'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node_set.rb:186:in `each'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/book.rb:27:in `map'
from /Users/me/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/creek-1.1.1/lib/creek/book.rb:27:in `sheets'
```