### PR TITLE
Refactor Creek::Sheet class

### DIFF
--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -21,13 +21,6 @@ module Creek
       @rid = rid
       @state = state
       @sheetfile = sheetfile
-
-      # An XLS file has only 256 columns, however, an XLSX or XLSM file can contain up to 16384 columns.
-      # This function creates a hash with all valid XLSX column names and associated indices.
-      @excel_col_names = Hash.new
-      (0...16384).each do |i|
-        @excel_col_names[col_name(i)] = i
-      end
     end
 
     ##
@@ -45,13 +38,6 @@ module Creek
     end
 
     private
-    ##
-    # Returns valid Excel column name for a given column index.
-    # For example, returns "A" for 0, "B" for 1 and "AQ" for 42.
-    def col_name i
-      quot = i/26
-      (quot>0 ? col_name(quot-1) : "") + (i%26+65).chr
-    end
 
     ##
     # Returns a hash per row that includes the cell ids and values.
@@ -64,7 +50,7 @@ module Creek
         opener = Nokogiri::XML::Reader::TYPE_ELEMENT
         closer = Nokogiri::XML::Reader::TYPE_END_ELEMENT
         Enumerator.new do |y|
-          shared, row, cells, cell = false, nil, {}, nil
+          row, cells, cell = nil, {}, nil
           cell_type  = nil
           cell_style_idx = nil
           @book.files.file.open(path) do |xml|
@@ -82,9 +68,8 @@ module Creek
                 cell_type      = node.attributes['t']
                 cell_style_idx = node.attributes['s']
                 cell           = node.attributes['r']
-
               elsif (node.name.eql? 'v') and (node.node_type.eql? opener)
-                if !cell.nil?
+                unless cell.nil?
                   cells[cell] = convert(node.inner_xml, cell_type, cell_style_idx)
                 end
               end
@@ -106,22 +91,18 @@ module Creek
     ##
     # The unzipped XML file does not contain any node for empty cells.
     # Empty cells are being padded in using this function
-    def fill_in_empty_cells cells, row_number, last_col
+    def fill_in_empty_cells(cells, row_number, last_col)
       new_cells = Hash.new
+
       unless cells.empty?
-        keys = cells.keys.sort
         last_col = last_col.gsub(row_number, '')
-        last_col_index = @excel_col_names[last_col]
-        [*(0..last_col_index)].each do |i|
-          col = col_name i
-          id = "#{col}#{row_number}"
-          unless cells.has_key? id
-              new_cells[id] = nil
-          else
-            new_cells[id] = cells[id]
-          end
+
+        ("A"..last_col).to_a.each do |column|
+          id = "#{column}#{row_number}"
+          new_cells[id] = cells[id]
         end
       end
+
       new_cells
     end
   end


### PR DESCRIPTION
Test code (with large 4MB xlsx file - 16 sheets and ~201.000 rows):
```ruby
MemoryProfiler.report do
  z = Creek::Book.new("tmp/4mb_testing_file.xlsx")
  z.sheets.each do |sheet|
    sheet.name
    sheet.state
  end
end.pretty_print
```

MemoryProfiler results:
**before (96366329 bytes - ~96 MB)**:
```
Total allocated: 96366329 bytes (2077427 objects)
Total retained:  1480 bytes (16 objects)

allocated memory by gem
-----------------------------------
  96098558  creek-1.1.1
    155841  rubyzip-1.2.0
    109258  nokogiri-1.6.7.2
      2592  2.3.0/lib
        80  other
```

**after (303337 bytes ~ 303 KB)**:
```
Total allocated: 303337 bytes (3555 objects)
Total retained:  1480 bytes (16 objects)

allocated memory by gem
-----------------------------------
    155841  rubyzip-1.2.0
    109258  nokogiri-1.6.7.2
     35566  creek/lib
      2592  2.3.0/lib
        80  other
```