### PR TITLE
more robust way to fetch remote file, httparty dependency added.

### DIFF
--- a/creek.gemspec
+++ b/creek.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'nokogiri', '~> 1.6.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
+  spec.add_dependency 'httparty', '~> 0.14.0'
 end


### PR DESCRIPTION
I did last pull request in a hurry, after some testing on real application it didn't work properly on all spreadsheets, this one is more robust. It's not using StringIO from `rubyzip` gem underneath, `httparty` dependency added though.