### PR TITLE
update nokogiri version

### DIFF
--- a/creek.gemspec
+++ b/creek.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.13.0'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'nokogiri', '~> 1.6.0'
+  spec.add_dependency 'nokogiri', '>= 1.6.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
 end


### PR DESCRIPTION
Nokogiri gem has been updated with several bug fixes as well as removing several ruby 2.4 warnings