### PR TITLE
Fix for temp image path

### DIFF
--- a/lib/creek/drawing.rb
+++ b/lib/creek/drawing.rb
@@ -34,12 +34,12 @@ module Creek
       return if pathnames_at_coordinate.empty?
 
       pathnames_at_coordinate.map do |image_pathname|
-         if image_pathname.exist?
-           image_pathname
-         else
-           excel_image_path = "xl/media/#{image_pathname.to_path.split(tmpdir).last}"
-           IO.copy_stream(@book.files.file.open(excel_image_path), image_pathname.to_path)
-           image_pathname
+        if image_pathname.exist?
+          image_pathname
+        else
+          excel_image_path = "xl/media#{image_pathname.to_path.split(tmpdir).last}"
+          IO.copy_stream(@book.files.file.open(excel_image_path), image_pathname.to_path)
+          image_pathname
          end
       end
     end
@@ -87,7 +87,7 @@ module Creek
         next if embed.nil?
 
         rid = embed.value
-        path = Pathname.new("#{tmpdir}#{extract_drawing_path(rid).slice(/[^\/]*$/)}")
+        path = Pathname.new("#{tmpdir}/#{extract_drawing_path(rid).slice(/[^\/]*$/)}")
 
         row_from = drawing.xpath(row_from_selector).text.to_i
         col_from = drawing.xpath(col_from_selector).text.to_i

--- a/spec/sheet_spec.rb
+++ b/spec/sheet_spec.rb
@@ -56,7 +56,7 @@ describe 'sheet' do
     context 'with excel without images' do
       it 'does not break on with_images' do
         rows = sheet_no_images.with_images.rows.map { |r| r }
-        expect(load_cell(rows, 'A10')).to eq(nil)
+        expect(load_cell(rows, 'A10')).to eq(0.15)
       end
     end
   end


### PR DESCRIPTION
There is a bug with temp images paths. The images are not all in one folder, but each image has unique path that looks like this:
`creek__drawing20170305-84409-134wljlimage2.jpeg`

This PR fixes it, and all images should now be in the same folder:
`creek__drawing20170305-84409-134wljl/image2.jpeg`