### PR TITLE
Updated gemspec to use latest version of nokogiri (1.8.0) which works…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Creek can simply parse an Excel file by looping through the rows enumerator:
 
 ```ruby
 require 'creek'
-creek = Creek::Book.new 'specs/fixtures/sample.xlsx'
+creek = Creek::Book.new 'spec/fixtures/sample.xlsx'
 sheet = creek.sheets[0]
 
 sheet.rows.each do |row|

--- a/creek.gemspec
+++ b/creek.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.6.0'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'nokogiri', '~> 1.7.0'
+  spec.add_dependency 'nokogiri', '~> 1.8.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
   spec.add_dependency 'httparty', '~> 0.15.5'
 end

--- a/creek.gemspec
+++ b/creek.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
 
   spec.add_dependency 'nokogiri', '~> 1.8.0'
-  spec.add_dependency 'rubyzip', '>= 1.0.0'
+  spec.add_dependency 'rubyzip', '>= 1.2.1'
   spec.add_dependency 'httparty', '~> 0.15.5'
 end


### PR DESCRIPTION
… with Ruby 2.4. Modified example code slightly in README to match project folder name ('spec' instead of 'specs').