### PR TITLE
Replace HTTParty with http.rb

### DIFF
--- a/creek.gemspec
+++ b/creek.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'nokogiri', '>= 1.7.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
-  spec.add_dependency 'httparty', '~> 0.15.5'
+  spec.add_dependency 'http', '~> 3.0.0'
 end

--- a/lib/creek/book.rb
+++ b/lib/creek/book.rb
@@ -1,7 +1,7 @@
 require 'zip/filesystem'
 require 'nokogiri'
 require 'date'
-require 'httparty'
+require 'http'
 
 module Creek
 
@@ -23,7 +23,7 @@ module Creek
       if options[:remote]
         zipfile = Tempfile.new("file")
         zipfile.binmode
-        zipfile.write(HTTParty.get(path).body)
+        zipfile.write(HTTP.get(path).to_s)
         zipfile.close
         path = zipfile.path
       end


### PR DESCRIPTION
Following up to #63, this replaces this gem's use of HTTParty with http.rb. I have tested this and it at least works in the successful case.

This would mean that nobody would have to see this message again just from using creek:

> Post-install message from httparty:
> When you HTTParty, you must party hard!

It also should be [noticeably faster](https://github.com/httprb/http#another-ruby-http-library-why-should-i-care).