### PR TITLE
Relax http dependency version

### DIFF
--- a/creek.gemspec
+++ b/creek.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'nokogiri', '>= 1.7.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
-  spec.add_dependency 'http', '~> 3.0.0'
+  spec.add_dependency 'http', '~> 3.0'
 end


### PR DESCRIPTION
It's useless and inconvenient to freeze this dependency to a patch-level version, especially since newer minor-level versions have been released.

That being said, great project, thanks for bringing it to life!