### PR TITLE
Ignore runs of phonetic that appears in Japanese

### DIFF
--- a/lib/creek/shared_strings.rb
+++ b/lib/creek/shared_strings.rb
@@ -29,7 +29,7 @@ module Creek
       dictionary = Hash.new
 
       xml.css('si').each_with_index do |si, idx|
-        text_nodes = si.css('t')
+        text_nodes = si.css('>t, r t')
         if text_nodes.count == 1 # plain text node
           dictionary[idx] = Creek::Styles::Converter.unescape_string(text_nodes.first.content)
         else # rich text nodes with text fragments

--- a/spec/fixtures/sst.xml
+++ b/spec/fixtures/sst.xml
@@ -78,4 +78,14 @@
     <si>
         <t>Cell with_x000D_escaped_x000D_characters</t>
     </si>
+    <si>
+        <t>吉田兼好</t>
+        <rPh sb="0" eb="2">
+            <t xml:space="preserve">ヨシダ </t>
+        </rPh>
+        <rPh sb="2" eb="4">
+            <t xml:space="preserve">ケンコウ </t>
+        </rPh>
+        <phoneticPr fontId="1"/>
+    </si>
 </sst>

--- a/spec/shared_string_spec.rb
+++ b/spec/shared_string_spec.rb
@@ -7,13 +7,14 @@ describe 'shared strings' do
     doc = Nokogiri::XML(shared_strings_xml_file)
     dictionary = Creek::SharedStrings.parse_shared_string_from_document(doc)
 
-    expect(dictionary.keys.size).to eq(6)
+    expect(dictionary.keys.size).to eq(7)
     expect(dictionary[0]).to eq('Cell A1')
     expect(dictionary[1]).to eq('Cell B1')
     expect(dictionary[2]).to eq('My Cell')
     expect(dictionary[3]).to eq('Cell A2')
     expect(dictionary[4]).to eq('Cell B2')
     expect(dictionary[5]).to eq("Cell with\rescaped\rcharacters")
+    expect(dictionary[6]).to eq('吉田兼好')
   end
 
 end


### PR DESCRIPTION
In Japanese, Excel automatically creates Kanji's phonetic styles.
They are not displayed in the cell of the Excel application.

For example:
<img width="572" alt="2019-02-20 21 23 12" src="https://user-images.githubusercontent.com/1079508/53091624-c67bb880-3555-11e9-81da-0047f09937c2.png">

They appears in OOXML as [rPh](https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_rPh_topic_ID0ELMS5.html) in `xl/sharedStrings.xml` like below:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="2" uniqueCount="2">
  <si>
    <t>吉田兼好</t>
    <rPh sb="0" eb="2">
      <t xml:space="preserve">ヨシダ </t>
    </rPh>
    <rPh sb="2" eb="4">
      <t xml:space="preserve">ケンコウ </t>
    </rPh>
    <phoneticPr fontId="1"/>
  </si>
</sst>
```

I think that most users need only the values in the cells of the Excel application.
So, I changed 'creek' to ignore the `rPh` tag in the` si` tag.