### PR TITLE
Bump http version to 4.0

### DIFF
--- a/creek.gemspec
+++ b/creek.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'nokogiri', '>= 1.7.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
-  spec.add_dependency 'http', '~> 3.0'
+  spec.add_dependency 'http', '~> 4.0'
 end


### PR DESCRIPTION
Given that this library only uses the `HTTP.get` method, I think it's safe to bump this version. The tests all seem to pass.