### PR TITLE
Remove http dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,19 @@ Creek will most likely return nil for a cell with images if there is no other te
 
 ## Remote files
 
+To download a remote file, use your favorite HTTP client to download to a
+temporary file. Here's an example:
+
 ```ruby
-remote_url = 'http://dev-builds.libreoffice.org/tmp/test.xlsx'
-Creek::Book.new remote_url, remote: true
+require 'http'
+
+zipfile = Tempfile.new("foo")
+zipfile.binmode
+zipfile.write(HTTP.get(path).to_s)
+zipfile.close
+path = zipfile.path
+
+Creek::Book.new path
 ```
 
 ## Contributing

--- a/creek.gemspec
+++ b/creek.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'nokogiri', '>= 1.7.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
-  spec.add_dependency 'http', '~> 4.0'
 end

--- a/lib/creek/book.rb
+++ b/lib/creek/book.rb
@@ -1,7 +1,6 @@
 require 'zip/filesystem'
 require 'nokogiri'
 require 'date'
-require 'http'
 
 module Creek
 
@@ -19,13 +18,6 @@ module Creek
       if check_file_extension
         extension = File.extname(options[:original_filename] || path).downcase
         raise 'Not a valid file format.' unless (['.xlsx', '.xlsm'].include? extension)
-      end
-      if options[:remote]
-        zipfile = Tempfile.new("file")
-        zipfile.binmode
-        zipfile.write(HTTP.get(path).to_s)
-        zipfile.close
-        path = zipfile.path
       end
       @files = Zip::File.open(path)
       @shared_strings = SharedStrings.new(self)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'creek'
 require 'pry'
+require 'time'
 

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -54,7 +54,7 @@ describe 'Creek parsing dates on a sample XLSX file' do
   end
 end
 
-describe 'Creek parsing a file with large numbrts.' do
+describe 'Creek parsing a file with large numbers.' do
   before(:all) do
     @creek = Creek::Book.new 'spec/fixtures/large_numbers.xlsx'
     @expected_simple_rows = [{"A"=>"7.83294732E8", "B"=>"783294732", "C"=>783294732.0}]


### PR DESCRIPTION
My project was using an older version of http and conflicted with this library. Instead of lowering the requirement, I decided to remove it completely and replace the scenario with a note in the readme with how the user can do it themselves.

Resolves #80 

I was also getting a failure when running `rake` for tests. Seems that `require 'time'` was missing