### PR TITLE
Remove http requirement and replace with OpenURI

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Once this is complete, you should be able to run the test suite:
 rake
 ```
 
+There are some remote tests that are excluded by default. To run those, run
+
+```
+bundle exec rspec --tag remote
+```
+
 ## Bug Reporting
 
 Please use the [Issues](https://github.com/pythonicrubyist/creek/issues) page to report bugs or suggest new enhancements.

--- a/creek.gemspec
+++ b/creek.gemspec
@@ -23,9 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec', '~> 3.6.0'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
 
   spec.add_dependency 'nokogiri', '>= 1.7.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
-  spec.add_dependency 'http', '~> 4.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
 require 'creek'
 require 'pry'
+require 'time'
 
+RSpec.configure do |config|
+  config.filter_run_excluding remote: true
+end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -106,6 +106,20 @@ describe 'Creek parsing a sample XLSX file' do
     expect(@creek).not_to be_nil
   end
 
+  it 'opens small remote files successfully', remote: true do
+    url = 'https://file-examples.com/wp-content/uploads/2017/02/file_example_XLSX_10.xlsx'
+    @creek = Creek::Book.new(url, remote: true)
+
+    expect(@creek.sheets[0]).to be_a Creek::Sheet
+  end
+
+  it 'opens large remote files successfully', remote: true do
+    url = 'http://www.house.leg.state.mn.us/comm/docs/BanaianZooExample.xlsx'
+    @creek = Creek::Book.new(url, remote: true)
+
+    expect(@creek.sheets[0]).to be_a Creek::Sheet
+  end
+
   it 'find sheets successfully.' do
     expect(@creek.sheets.count).to eq(1)
     sheet = @creek.sheets.first


### PR DESCRIPTION
Related #81 and Resolves #80 

There were no tests for parsing remote files, so I added them but wasn't sure where to find a good online sample. I googled for some public files that fit two scenarios, and excluded these tests from running by default since they hit the internet.

This removes the `http` gem dependency and replaces it with Ruby's stdlib `open-uri`

Also, running `rake` failed for me because it didn't have `require 'time'`, so I added that.