### PR TITLE
Fix BigDecimal

### DIFF
--- a/lib/creek/styles/converter.rb
+++ b/lib/creek/styles/converter.rb
@@ -110,7 +110,7 @@ module Creek
 
       def self.convert_bignum(value)
         if defined?(BigDecimal)
-          BigDecimal.new(value)
+          BigDecimal(value)
         else
           value.to_f
         end


### PR DESCRIPTION
`BigDecimal.new` has been removed in ruby 2.7. Therefore converting big decimals is broken.
Use `BigDecimal(value)` instead.
https://ruby-doc.org/stdlib-2.7.1/libdoc/bigdecimal/rdoc/BigDecimal.html