### PR TITLE
Reset headers each time when creating the enumerator

### DIFF
--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -92,6 +92,7 @@ module Creek
         opener = Nokogiri::XML::Reader::TYPE_ELEMENT
         closer = Nokogiri::XML::Reader::TYPE_END_ELEMENT
         Enumerator.new do |y|
+          @headers = nil
           row, cells, cell = nil, {}, nil
           cell_type = nil
           cell_style_idx = nil
@@ -104,7 +105,7 @@ module Creek
                 y << (include_meta_data ? row : cells) if node.self_closing?
               elsif node.name == 'row' && node.node_type == closer
                 processed_cells = fill_in_empty_cells(cells, row['r'], cell, use_simple_rows_format)
-                @headers = processed_cells if row['r'] == HEADERS_ROW_NUMBER
+                @headers = processed_cells if with_headers && row['r'] == HEADERS_ROW_NUMBER
 
                 if @images_present
                   processed_cells.each do |cell_name, cell_value|
@@ -177,7 +178,7 @@ module Creek
       parse_xml(sheet_rels_filepath).css("Relationship[@Id='#{drawing_rid}']").first.attributes['Target'].value
     end
 
-    def cell_id(column, use_simple_rows_format, row_number = '')
+    def cell_id(column, use_simple_rows_format, row_number)
       return "#{column}#{row_number}" unless use_simple_rows_format
 
       with_headers && headers ? headers[column] : column

--- a/spec/sheet_spec.rb
+++ b/spec/sheet_spec.rb
@@ -112,12 +112,22 @@ describe 'sheet' do
     context 'when enable with_headers property' do
       before { sheet.with_headers = true }
 
-      subject { sheet.simple_rows.to_a[1] }
-
       it 'returns values by headers name' do
         expect(subject['HeaderA']).to eq 'value1'
         expect(subject['HeaderB']).to eq 'value2'
         expect(subject['HeaderC']).to eq 'value3'
+      end
+
+      it 'returns headers correctly when called multiple times' do
+        row = sheet.simple_rows.to_a[1]
+        expect(row['HeaderA']).to eq 'value1'
+        expect(row['HeaderB']).to eq 'value2'
+        expect(row['HeaderC']).to eq 'value3'
+
+        row = sheet.simple_rows.to_a[1]
+        expect(row['HeaderA']).to eq 'value1'
+        expect(row['HeaderB']).to eq 'value2'
+        expect(row['HeaderC']).to eq 'value3'
       end
     end
   end


### PR DESCRIPTION
When with_headers: true is used and `#simple_rows` is called multiple times, the headers/values get messed up. This PR fixes it by resetting the headers when creating the enumerator.

Before:
```ruby
sheet.simple_rows.to_a[1]
=> {"HeaderA"=>"value1", "HeaderB"=>"value2", "HeaderC"=>"value3"}
sheet.simple_rows.to_a[1]
=> {nil=>"value3"}
```

After:
```ruby
sheet.simple_rows.to_a[1]
=> {"HeaderA"=>"value1", "HeaderB"=>"value2", "HeaderC"=>"value3"}
sheet.simple_rows.to_a[1]
=> {"HeaderA"=>"value1", "HeaderB"=>"value2", "HeaderC"=>"value3"}
```