### PR TITLE
Removes unused attr_reader and memoizes Book#sheets

### DIFF
--- a/lib/creek/book.rb
+++ b/lib/creek/book.rb
@@ -6,7 +6,6 @@ require 'open-uri'
 module Creek
   class Creek::Book
     attr_reader :files,
-                :sheets,
                 :shared_strings,
                 :with_headers
 
@@ -26,32 +25,34 @@ module Creek
     end
 
     def sheets
-      doc = @files.file.open "xl/workbook.xml"
-      xml = Nokogiri::XML::Document.parse doc
-      namespaces = xml.namespaces
+      @sheets ||= begin
+        doc = @files.file.open "xl/workbook.xml"
+        xml = Nokogiri::XML::Document.parse doc
+        namespaces = xml.namespaces
 
-      cssPrefix = ''
-      namespaces.each do |namespace|
-        if namespace[1] == 'http://schemas.openxmlformats.org/spreadsheetml/2006/main' && namespace[0] != 'xmlns' then
-          cssPrefix = namespace[0].split(':')[1]+'|'
+        cssPrefix = ''
+        namespaces.each do |namespace|
+          if namespace[1] == 'http://schemas.openxmlformats.org/spreadsheetml/2006/main' && namespace[0] != 'xmlns' then
+            cssPrefix = namespace[0].split(':')[1]+'|'
+          end
         end
-      end
 
-      rels_doc = @files.file.open "xl/_rels/workbook.xml.rels"
-      rels = Nokogiri::XML::Document.parse(rels_doc).css("Relationship")
-      @sheets = xml.css(cssPrefix+'sheet').map do |sheet|
-        sheetfile = rels.find { |el| sheet.attr("r:id") == el.attr("Id") }.attr("Target")
-        sheet = Sheet.new(
-          self,
-          sheet.attr("name"),
-          sheet.attr("sheetid"),
-          sheet.attr("state"),
-          sheet.attr("visible"),
-          sheet.attr("r:id"),
-          sheetfile
-        )
-        sheet.with_headers = with_headers
-        sheet
+        rels_doc = @files.file.open "xl/_rels/workbook.xml.rels"
+        rels = Nokogiri::XML::Document.parse(rels_doc).css("Relationship")
+        xml.css(cssPrefix+'sheet').map do |sheet|
+          sheetfile = rels.find { |el| sheet.attr("r:id") == el.attr("Id") }.attr("Target")
+          sheet = Sheet.new(
+            self,
+            sheet.attr("name"),
+            sheet.attr("sheetid"),
+            sheet.attr("state"),
+            sheet.attr("visible"),
+            sheet.attr("r:id"),
+            sheetfile
+          )
+          sheet.with_headers = with_headers
+          sheet
+        end
       end
     end
 


### PR DESCRIPTION
This pr removes the `sheets` attr reader in `Book` because it was overwritten by the declared `#sheets` method.  It also memoizes `sheets` which is presumably the original intent with the attr_reader but not sure.

Fixes `warning: method redefined; discarding old sheets`