### PR TITLE
Optimize `Sheet#rows_generator` method to use less memory and parse faster

### DIFF
--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -131,12 +131,13 @@ module Creek
                 cells[cell] = convert(node.value, cell_type, cell_style_idx)
               end
             elsif node_name == name_c && node_type == opener
-              # attribute_hash avoids the namespaces lookup + merge that
-              # Reader#attributes performs on every call; we only need t/s/r.
-              attributes     = node.attribute_hash
-              cell_type      = attributes['t']
-              cell_style_idx = attributes['s']
-              cell           = attributes['r']
+              # Fetch the three attributes individually rather than via
+              # attribute_hash/attributes: with hundreds of thousands of cells
+              # the per-cell Hash allocation dominates, so three cheap C lookups
+              # are both faster and leaner than building and indexing a hash.
+              cell_type      = node.attribute('t')
+              cell_style_idx = node.attribute('s')
+              cell           = node.attribute('r')
             elsif node_name == name_row && node_type == opener
               row = node.attribute_hash
               row['cells'] = {}

--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -101,30 +101,48 @@ module Creek
         cell_type = nil
         cell_style_idx = nil
         @book.files.file.open(path) do |xml|
-          prefix = ''
+          namespace_resolved = false
           name_row = 'row'
           name_c = 'c'
           name_v = 'v'
           name_t = 't'
           Nokogiri::XML::Reader.from_io(xml).each do |node|
-            if prefix.empty? && node.namespaces.any?
+            # Resolve the namespace prefix once, from the first element that
+            # declares the spreadsheetml namespace (the worksheet root). Caching
+            # this avoids allocating a namespaces hash for every node in the stream.
+            if !namespace_resolved && node.namespaces.any?
               namespace = node.namespaces.detect { |_key, uri| uri == SPREADSHEETML_URI }
-              prefix = if namespace && namespace[0].start_with?('xmlns:')
-                         namespace[0].delete_prefix('xmlns:') + ':'
-                       else
-                         ''
-                       end
-              name_row = "#{prefix}row"
-              name_c = "#{prefix}c"
-              name_v = "#{prefix}v"
-              name_t = "#{prefix}t"
+              if namespace
+                prefix = namespace[0].start_with?('xmlns:') ? namespace[0].delete_prefix('xmlns:') + ':' : ''
+                name_row = "#{prefix}row"
+                name_c = "#{prefix}c"
+                name_v = "#{prefix}v"
+                name_t = "#{prefix}t"
+                namespace_resolved = true
+              end
             end
-            if node.name == name_row && node.node_type == opener
-              row = node.attributes
+
+            node_name = node.name
+            node_type = node.node_type
+
+            if node_type == opener && (node_name == name_v || node_name == name_t)
+              unless cell.nil?
+                node.read
+                cells[cell] = convert(node.value, cell_type, cell_style_idx)
+              end
+            elsif node_name == name_c && node_type == opener
+              # attribute_hash avoids the namespaces lookup + merge that
+              # Reader#attributes performs on every call; we only need t/s/r.
+              attributes     = node.attribute_hash
+              cell_type      = attributes['t']
+              cell_style_idx = attributes['s']
+              cell           = attributes['r']
+            elsif node_name == name_row && node_type == opener
+              row = node.attribute_hash
               row['cells'] = {}
               cells = {}
               y << (include_meta_data ? row : cells) if node.self_closing?
-            elsif node.name == name_row && node.node_type == closer
+            elsif node_name == name_row && node_type == closer
               processed_cells = fill_in_empty_cells(cells, row['r'], cell, use_simple_rows_format)
               @headers = processed_cells if with_headers && row['r'] == HEADERS_ROW_NUMBER
 
@@ -138,15 +156,6 @@ module Creek
 
               row['cells'] = processed_cells
               y << (include_meta_data ? row : processed_cells)
-            elsif node.name == name_c && node.node_type == opener
-              cell_type      = node.attributes['t']
-              cell_style_idx = node.attributes['s']
-              cell           = node.attributes['r']
-            elsif (node.name == name_v || node.name == name_t) && node.node_type == opener
-              unless cell.nil?
-                node.read
-                cells[cell] = convert(node.value, cell_type, cell_style_idx)
-              end
             end
           end
         end
@@ -172,8 +181,8 @@ module Creek
       new_cells = {}
       return new_cells if cells.empty?
 
-      last_col = last_col.gsub(row_number, '')
-      ('A'..last_col).to_a.each do |column|
+      last_col = last_col.delete_suffix(row_number)
+      ('A'..last_col).each do |column|
         id = cell_id(column, use_simple_rows_format, row_number)
         new_cells[id] = cells["#{column}#{row_number}"]
       end


### PR DESCRIPTION
After noticing that this method uses a lot of memory/takes a lot of time in the Rails app at work, I used Claude to optimize this and then verify that the output was identical from the released gem vs this change on a number of different files.

This should hopefully help resolve some long-standing issues with the performance/memory usage of the gem.

---

Benchmarked on a generated 20,000-row x 40-col xlsx (mixed shared-string, numeric, and empty cells). Median full-parse time dropped ~1.72x (1.85s -> ~1.08s) and allocations dropped ~3.75x (28.6M -> 7.63M), with byte-identical output verified on both default- and prefixed-namespace files across `rows`, `simple_rows`, and `rows_with_meta_data` (including the self-closing-row + meta-data path).

Changes, in order of impact:

- Resolve the namespace prefix once via a `namespace_resolved` flag instead of re-checking `node.namespaces` on every node. Worksheets use a default namespace, so the old `prefix.empty?` guard never latched and allocated a namespaces hash for every node in the stream (660,002 calls -> 2). This is the bulk of the wall-clock win.
- Hoist `node.name`/`node.node_type` into locals (each was read up to 4x per node in the if/elsif chain) and reorder branches so the hottest nodes (`<v>`/`<c>`) are tested first.
- Fetch cell attributes with three individual `node.attribute('t'/'s'/'r')` C calls instead of `node.attributes`. `Reader#attributes` is `attribute_hash.merge(namespaces)`, so it built and merged a namespaces hash on every call. With hundreds of thousands of cells the per-cell Hash allocation dominates, so three cheap lookups are both faster and leaner than building and indexing a hash.
- Use `node.attribute_hash` for the row-opener node (only ~one per row): this avoids the namespaces merge that `node.attributes` performs while preserving the exact meta-data row hash. Safe because xlsx row elements never declare their own namespaces (the namespace hash is empty for them), so the result is identical -- confirmed byte-for-byte including the self-closing-row + meta-data path.
- In `fill_in_empty_cells`, drop the redundant `.to_a` on the column range and use `delete_suffix` instead of `gsub` to strip the row number.

---

| Metric                     | Baseline | Optimized | Change            |
|----------------------------|----------|-----------|-------------------|
| Median full-parse time     | 1.853s   | ~1.08s    | ~1.72× faster     |
| Min full-parse time        | 1.827s   | ~1.04s    | ~1.76× faster     |
| Allocations per parse      | 28.6M    | 7.63M     | ~3.75× fewer      |
| `Reader#namespaces` calls  | 660,002  | 2         | ~330,000× fewer   |
| `Reader#attributes` calls  | 660,000  | 0         | eliminated        |

| Stage                              | Median  | Allocations |
|------------------------------------|---------|-------------|
| Baseline                           | 1.853s  | 28.6M       |
| + namespace flag, hoist, reorder   | ~1.11s  | ~9.8M       |
| + attribute_hash (rows)            | ~1.10s  | 9.23M       |
| + node.attribute() per cell attr   | ~1.08s  | 7.63M       |
| Total                              | ~1.08s  | 7.63M       |
